### PR TITLE
AGR-2528 chipmunk (FMS) dockerhub => ECR code-changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG ALLIANCE_RELEASE=latest
-FROM agrdocker/agr_base_linux_env:${ALLIANCE_RELEASE}
+ARG REG=100225593120.dkr.ecr.us-east-1.amazonaws.com
+
+FROM ${REG}/agr_base_linux_env:${ALLIANCE_RELEASE}
   
 RUN mkdir /data
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+REG := 100225593120.dkr.ecr.us-east-1.amazonaws.com
+ALLIANCE_RELEASE := latest
+
+registry-docker-login:
+ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
+	@$(eval DOCKER_LOGIN_CMD=aws)
+ifneq (${AWS_PROFILE},)
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
+endif
+	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} ecr get-login-password | docker login -u AWS --password-stdin https://${REG})
+	${DOCKER_LOGIN_CMD}
+endif
+
 all: build
 
 run:
@@ -8,8 +21,8 @@ build:
 
 apirun: build run
 
-dockerbuild:
-	docker build --no-cache -t agrdocker/agr_fms_software .
+dockerbuild: registry-docker-login
+	docker build --no-cache -t ${REG}/agr_fms_software:${ALLIANCE_RELEASE} --build-arg REG=${REG} .
 
 apidebug: build debug
 


### PR DESCRIPTION
Code changes to support building the FMS software image using the base image from ECR (through GoCD and make). Analoguous to alliance-genome/agr_ansible_devops#15.